### PR TITLE
Fix weapon upgrade because the upgrading weapon packet and calculate …

### DIFF
--- a/src/generated/main/java/emu/grasscutter/net/proto/CalcWeaponUpgradeReturnItemsReqOuterClass.java
+++ b/src/generated/main/java/emu/grasscutter/net/proto/CalcWeaponUpgradeReturnItemsReqOuterClass.java
@@ -19,48 +19,48 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> 
         getItemParamListList();
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam getItemParamList(int index);
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     int getItemParamListCount();
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     java.util.List<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> 
         getItemParamListOrBuilderList();
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder getItemParamListOrBuilder(
         int index);
 
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
      * @return A list containing the foodWeaponGuidList.
      */
     java.util.List<java.lang.Long> getFoodWeaponGuidListList();
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
      * @return The count of foodWeaponGuidList.
      */
     int getFoodWeaponGuidListCount();
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
      * @param index The index of the element to return.
      * @return The foodWeaponGuidList at the given index.
      */
     long getFoodWeaponGuidList(int index);
 
     /**
-     * <code>uint64 target_weapon_guid = 14;</code>
+     * <code>uint64 target_weapon_guid = 4;</code>
      * @return The targetWeaponGuid.
      */
     long getTargetWeaponGuid();
@@ -113,21 +113,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
             case 0:
               done = true;
               break;
-            case 66: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                itemParamList_ = new java.util.ArrayList<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              itemParamList_.add(
-                  input.readMessage(emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.parser(), extensionRegistry));
-              break;
-            }
-            case 112: {
-
-              targetWeaponGuid_ = input.readUInt64();
-              break;
-            }
-            case 120: {
+            case 8: {
               if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 foodWeaponGuidList_ = newLongList();
                 mutable_bitField0_ |= 0x00000002;
@@ -135,7 +121,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
               foodWeaponGuidList_.addLong(input.readUInt64());
               break;
             }
-            case 122: {
+            case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
               if (!((mutable_bitField0_ & 0x00000002) != 0) && input.getBytesUntilLimit() > 0) {
@@ -146,6 +132,20 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
                 foodWeaponGuidList_.addLong(input.readUInt64());
               }
               input.popLimit(limit);
+              break;
+            }
+            case 32: {
+
+              targetWeaponGuid_ = input.readUInt64();
+              break;
+            }
+            case 82: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                itemParamList_ = new java.util.ArrayList<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              itemParamList_.add(
+                  input.readMessage(emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -163,11 +163,11 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          itemParamList_ = java.util.Collections.unmodifiableList(itemParamList_);
-        }
         if (((mutable_bitField0_ & 0x00000002) != 0)) {
           foodWeaponGuidList_.makeImmutable(); // C
+        }
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          itemParamList_ = java.util.Collections.unmodifiableList(itemParamList_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -186,17 +186,17 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
               emu.grasscutter.net.proto.CalcWeaponUpgradeReturnItemsReqOuterClass.CalcWeaponUpgradeReturnItemsReq.class, emu.grasscutter.net.proto.CalcWeaponUpgradeReturnItemsReqOuterClass.CalcWeaponUpgradeReturnItemsReq.Builder.class);
     }
 
-    public static final int ITEM_PARAM_LIST_FIELD_NUMBER = 8;
+    public static final int ITEM_PARAM_LIST_FIELD_NUMBER = 10;
     private java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> itemParamList_;
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     @java.lang.Override
     public java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> getItemParamListList() {
       return itemParamList_;
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     @java.lang.Override
     public java.util.List<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> 
@@ -204,21 +204,21 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
       return itemParamList_;
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     @java.lang.Override
     public int getItemParamListCount() {
       return itemParamList_.size();
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     @java.lang.Override
     public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam getItemParamList(int index) {
       return itemParamList_.get(index);
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 8;</code>
+     * <code>repeated .ItemParam item_param_list = 10;</code>
      */
     @java.lang.Override
     public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder getItemParamListOrBuilder(
@@ -226,10 +226,10 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
       return itemParamList_.get(index);
     }
 
-    public static final int FOOD_WEAPON_GUID_LIST_FIELD_NUMBER = 15;
+    public static final int FOOD_WEAPON_GUID_LIST_FIELD_NUMBER = 1;
     private com.google.protobuf.Internal.LongList foodWeaponGuidList_;
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
      * @return A list containing the foodWeaponGuidList.
      */
     @java.lang.Override
@@ -238,14 +238,14 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
       return foodWeaponGuidList_;
     }
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
      * @return The count of foodWeaponGuidList.
      */
     public int getFoodWeaponGuidListCount() {
       return foodWeaponGuidList_.size();
     }
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
      * @param index The index of the element to return.
      * @return The foodWeaponGuidList at the given index.
      */
@@ -254,10 +254,10 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
     }
     private int foodWeaponGuidListMemoizedSerializedSize = -1;
 
-    public static final int TARGET_WEAPON_GUID_FIELD_NUMBER = 14;
+    public static final int TARGET_WEAPON_GUID_FIELD_NUMBER = 4;
     private long targetWeaponGuid_;
     /**
-     * <code>uint64 target_weapon_guid = 14;</code>
+     * <code>uint64 target_weapon_guid = 4;</code>
      * @return The targetWeaponGuid.
      */
     @java.lang.Override
@@ -280,18 +280,18 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
-      for (int i = 0; i < itemParamList_.size(); i++) {
-        output.writeMessage(8, itemParamList_.get(i));
-      }
-      if (targetWeaponGuid_ != 0L) {
-        output.writeUInt64(14, targetWeaponGuid_);
-      }
       if (getFoodWeaponGuidListList().size() > 0) {
-        output.writeUInt32NoTag(122);
+        output.writeUInt32NoTag(10);
         output.writeUInt32NoTag(foodWeaponGuidListMemoizedSerializedSize);
       }
       for (int i = 0; i < foodWeaponGuidList_.size(); i++) {
         output.writeUInt64NoTag(foodWeaponGuidList_.getLong(i));
+      }
+      if (targetWeaponGuid_ != 0L) {
+        output.writeUInt64(4, targetWeaponGuid_);
+      }
+      for (int i = 0; i < itemParamList_.size(); i++) {
+        output.writeMessage(10, itemParamList_.get(i));
       }
       unknownFields.writeTo(output);
     }
@@ -302,14 +302,6 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
       if (size != -1) return size;
 
       size = 0;
-      for (int i = 0; i < itemParamList_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(8, itemParamList_.get(i));
-      }
-      if (targetWeaponGuid_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(14, targetWeaponGuid_);
-      }
       {
         int dataSize = 0;
         for (int i = 0; i < foodWeaponGuidList_.size(); i++) {
@@ -323,6 +315,14 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
               .computeInt32SizeNoTag(dataSize);
         }
         foodWeaponGuidListMemoizedSerializedSize = dataSize;
+      }
+      if (targetWeaponGuid_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(4, targetWeaponGuid_);
+      }
+      for (int i = 0; i < itemParamList_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(10, itemParamList_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -683,7 +683,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
           emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> itemParamListBuilder_;
 
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> getItemParamListList() {
         if (itemParamListBuilder_ == null) {
@@ -693,7 +693,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public int getItemParamListCount() {
         if (itemParamListBuilder_ == null) {
@@ -703,7 +703,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam getItemParamList(int index) {
         if (itemParamListBuilder_ == null) {
@@ -713,7 +713,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder setItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam value) {
@@ -730,7 +730,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder setItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder builderForValue) {
@@ -744,7 +744,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder addItemParamList(emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam value) {
         if (itemParamListBuilder_ == null) {
@@ -760,7 +760,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder addItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam value) {
@@ -777,7 +777,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder addItemParamList(
           emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder builderForValue) {
@@ -791,7 +791,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder addItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder builderForValue) {
@@ -805,7 +805,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder addAllItemParamList(
           java.lang.Iterable<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> values) {
@@ -820,7 +820,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder clearItemParamList() {
         if (itemParamListBuilder_ == null) {
@@ -833,7 +833,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public Builder removeItemParamList(int index) {
         if (itemParamListBuilder_ == null) {
@@ -846,14 +846,14 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder getItemParamListBuilder(
           int index) {
         return getItemParamListFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder getItemParamListOrBuilder(
           int index) {
@@ -863,7 +863,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public java.util.List<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> 
            getItemParamListOrBuilderList() {
@@ -874,14 +874,14 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder addItemParamListBuilder() {
         return getItemParamListFieldBuilder().addBuilder(
             emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.getDefaultInstance());
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder addItemParamListBuilder(
           int index) {
@@ -889,7 +889,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
             index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.getDefaultInstance());
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 8;</code>
+       * <code>repeated .ItemParam item_param_list = 10;</code>
        */
       public java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder> 
            getItemParamListBuilderList() {
@@ -918,7 +918,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
          }
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @return A list containing the foodWeaponGuidList.
        */
       public java.util.List<java.lang.Long>
@@ -927,14 +927,14 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
                  java.util.Collections.unmodifiableList(foodWeaponGuidList_) : foodWeaponGuidList_;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @return The count of foodWeaponGuidList.
        */
       public int getFoodWeaponGuidListCount() {
         return foodWeaponGuidList_.size();
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @param index The index of the element to return.
        * @return The foodWeaponGuidList at the given index.
        */
@@ -942,7 +942,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return foodWeaponGuidList_.getLong(index);
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @param index The index to set the value at.
        * @param value The foodWeaponGuidList to set.
        * @return This builder for chaining.
@@ -955,7 +955,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @param value The foodWeaponGuidList to add.
        * @return This builder for chaining.
        */
@@ -966,7 +966,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @param values The foodWeaponGuidList to add.
        * @return This builder for chaining.
        */
@@ -979,7 +979,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearFoodWeaponGuidList() {
@@ -991,7 +991,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
 
       private long targetWeaponGuid_ ;
       /**
-       * <code>uint64 target_weapon_guid = 14;</code>
+       * <code>uint64 target_weapon_guid = 4;</code>
        * @return The targetWeaponGuid.
        */
       @java.lang.Override
@@ -999,7 +999,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return targetWeaponGuid_;
       }
       /**
-       * <code>uint64 target_weapon_guid = 14;</code>
+       * <code>uint64 target_weapon_guid = 4;</code>
        * @param value The targetWeaponGuid to set.
        * @return This builder for chaining.
        */
@@ -1010,7 +1010,7 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
         return this;
       }
       /**
-       * <code>uint64 target_weapon_guid = 14;</code>
+       * <code>uint64 target_weapon_guid = 4;</code>
        * @return This builder for chaining.
        */
       public Builder clearTargetWeaponGuid() {
@@ -1088,9 +1088,9 @@ public final class CalcWeaponUpgradeReturnItemsReqOuterClass {
     java.lang.String[] descriptorData = {
       "\n%CalcWeaponUpgradeReturnItemsReq.proto\032" +
       "\017ItemParam.proto\"\201\001\n\037CalcWeaponUpgradeRe" +
-      "turnItemsReq\022#\n\017item_param_list\030\010 \003(\0132\n." +
-      "ItemParam\022\035\n\025food_weapon_guid_list\030\017 \003(\004" +
-      "\022\032\n\022target_weapon_guid\030\016 \001(\004B\033\n\031emu.gras" +
+      "turnItemsReq\022#\n\017item_param_list\030\n \003(\0132\n." +
+      "ItemParam\022\035\n\025food_weapon_guid_list\030\001 \003(\004" +
+      "\022\032\n\022target_weapon_guid\030\004 \001(\004B\033\n\031emu.gras" +
       "scutter.net.protob\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor

--- a/src/generated/main/java/emu/grasscutter/net/proto/WeaponUpgradeReqOuterClass.java
+++ b/src/generated/main/java/emu/grasscutter/net/proto/WeaponUpgradeReqOuterClass.java
@@ -19,48 +19,48 @@ public final class WeaponUpgradeReqOuterClass {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> 
         getItemParamListList();
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam getItemParamList(int index);
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     int getItemParamListCount();
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     java.util.List<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> 
         getItemParamListOrBuilderList();
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder getItemParamListOrBuilder(
         int index);
 
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
      * @return A list containing the foodWeaponGuidList.
      */
     java.util.List<java.lang.Long> getFoodWeaponGuidListList();
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
      * @return The count of foodWeaponGuidList.
      */
     int getFoodWeaponGuidListCount();
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
      * @param index The index of the element to return.
      * @return The foodWeaponGuidList at the given index.
      */
     long getFoodWeaponGuidList(int index);
 
     /**
-     * <code>uint64 target_weapon_guid = 4;</code>
+     * <code>uint64 target_weapon_guid = 14;</code>
      * @return The targetWeaponGuid.
      */
     long getTargetWeaponGuid();
@@ -113,7 +113,21 @@ public final class WeaponUpgradeReqOuterClass {
             case 0:
               done = true;
               break;
-            case 8: {
+            case 66: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                itemParamList_ = new java.util.ArrayList<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              itemParamList_.add(
+                  input.readMessage(emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.parser(), extensionRegistry));
+              break;
+            }
+            case 112: {
+
+              targetWeaponGuid_ = input.readUInt64();
+              break;
+            }
+            case 120: {
               if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 foodWeaponGuidList_ = newLongList();
                 mutable_bitField0_ |= 0x00000002;
@@ -121,7 +135,7 @@ public final class WeaponUpgradeReqOuterClass {
               foodWeaponGuidList_.addLong(input.readUInt64());
               break;
             }
-            case 10: {
+            case 122: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
               if (!((mutable_bitField0_ & 0x00000002) != 0) && input.getBytesUntilLimit() > 0) {
@@ -132,20 +146,6 @@ public final class WeaponUpgradeReqOuterClass {
                 foodWeaponGuidList_.addLong(input.readUInt64());
               }
               input.popLimit(limit);
-              break;
-            }
-            case 32: {
-
-              targetWeaponGuid_ = input.readUInt64();
-              break;
-            }
-            case 82: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                itemParamList_ = new java.util.ArrayList<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              itemParamList_.add(
-                  input.readMessage(emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -163,11 +163,11 @@ public final class WeaponUpgradeReqOuterClass {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) != 0)) {
-          foodWeaponGuidList_.makeImmutable(); // C
-        }
         if (((mutable_bitField0_ & 0x00000001) != 0)) {
           itemParamList_ = java.util.Collections.unmodifiableList(itemParamList_);
+        }
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
+          foodWeaponGuidList_.makeImmutable(); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -186,17 +186,17 @@ public final class WeaponUpgradeReqOuterClass {
               emu.grasscutter.net.proto.WeaponUpgradeReqOuterClass.WeaponUpgradeReq.class, emu.grasscutter.net.proto.WeaponUpgradeReqOuterClass.WeaponUpgradeReq.Builder.class);
     }
 
-    public static final int ITEM_PARAM_LIST_FIELD_NUMBER = 10;
+    public static final int ITEM_PARAM_LIST_FIELD_NUMBER = 8;
     private java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> itemParamList_;
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     @java.lang.Override
     public java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> getItemParamListList() {
       return itemParamList_;
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     @java.lang.Override
     public java.util.List<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> 
@@ -204,21 +204,21 @@ public final class WeaponUpgradeReqOuterClass {
       return itemParamList_;
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     @java.lang.Override
     public int getItemParamListCount() {
       return itemParamList_.size();
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     @java.lang.Override
     public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam getItemParamList(int index) {
       return itemParamList_.get(index);
     }
     /**
-     * <code>repeated .ItemParam item_param_list = 10;</code>
+     * <code>repeated .ItemParam item_param_list = 8;</code>
      */
     @java.lang.Override
     public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder getItemParamListOrBuilder(
@@ -226,10 +226,10 @@ public final class WeaponUpgradeReqOuterClass {
       return itemParamList_.get(index);
     }
 
-    public static final int FOOD_WEAPON_GUID_LIST_FIELD_NUMBER = 1;
+    public static final int FOOD_WEAPON_GUID_LIST_FIELD_NUMBER = 15;
     private com.google.protobuf.Internal.LongList foodWeaponGuidList_;
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
      * @return A list containing the foodWeaponGuidList.
      */
     @java.lang.Override
@@ -238,14 +238,14 @@ public final class WeaponUpgradeReqOuterClass {
       return foodWeaponGuidList_;
     }
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
      * @return The count of foodWeaponGuidList.
      */
     public int getFoodWeaponGuidListCount() {
       return foodWeaponGuidList_.size();
     }
     /**
-     * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+     * <code>repeated uint64 food_weapon_guid_list = 15;</code>
      * @param index The index of the element to return.
      * @return The foodWeaponGuidList at the given index.
      */
@@ -254,10 +254,10 @@ public final class WeaponUpgradeReqOuterClass {
     }
     private int foodWeaponGuidListMemoizedSerializedSize = -1;
 
-    public static final int TARGET_WEAPON_GUID_FIELD_NUMBER = 4;
+    public static final int TARGET_WEAPON_GUID_FIELD_NUMBER = 14;
     private long targetWeaponGuid_;
     /**
-     * <code>uint64 target_weapon_guid = 4;</code>
+     * <code>uint64 target_weapon_guid = 14;</code>
      * @return The targetWeaponGuid.
      */
     @java.lang.Override
@@ -280,18 +280,18 @@ public final class WeaponUpgradeReqOuterClass {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
+      for (int i = 0; i < itemParamList_.size(); i++) {
+        output.writeMessage(8, itemParamList_.get(i));
+      }
+      if (targetWeaponGuid_ != 0L) {
+        output.writeUInt64(14, targetWeaponGuid_);
+      }
       if (getFoodWeaponGuidListList().size() > 0) {
-        output.writeUInt32NoTag(10);
+        output.writeUInt32NoTag(122);
         output.writeUInt32NoTag(foodWeaponGuidListMemoizedSerializedSize);
       }
       for (int i = 0; i < foodWeaponGuidList_.size(); i++) {
         output.writeUInt64NoTag(foodWeaponGuidList_.getLong(i));
-      }
-      if (targetWeaponGuid_ != 0L) {
-        output.writeUInt64(4, targetWeaponGuid_);
-      }
-      for (int i = 0; i < itemParamList_.size(); i++) {
-        output.writeMessage(10, itemParamList_.get(i));
       }
       unknownFields.writeTo(output);
     }
@@ -302,6 +302,14 @@ public final class WeaponUpgradeReqOuterClass {
       if (size != -1) return size;
 
       size = 0;
+      for (int i = 0; i < itemParamList_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, itemParamList_.get(i));
+      }
+      if (targetWeaponGuid_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(14, targetWeaponGuid_);
+      }
       {
         int dataSize = 0;
         for (int i = 0; i < foodWeaponGuidList_.size(); i++) {
@@ -315,14 +323,6 @@ public final class WeaponUpgradeReqOuterClass {
               .computeInt32SizeNoTag(dataSize);
         }
         foodWeaponGuidListMemoizedSerializedSize = dataSize;
-      }
-      if (targetWeaponGuid_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(4, targetWeaponGuid_);
-      }
-      for (int i = 0; i < itemParamList_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(10, itemParamList_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -683,7 +683,7 @@ public final class WeaponUpgradeReqOuterClass {
           emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> itemParamListBuilder_;
 
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> getItemParamListList() {
         if (itemParamListBuilder_ == null) {
@@ -693,7 +693,7 @@ public final class WeaponUpgradeReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public int getItemParamListCount() {
         if (itemParamListBuilder_ == null) {
@@ -703,7 +703,7 @@ public final class WeaponUpgradeReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam getItemParamList(int index) {
         if (itemParamListBuilder_ == null) {
@@ -713,7 +713,7 @@ public final class WeaponUpgradeReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder setItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam value) {
@@ -730,7 +730,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder setItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder builderForValue) {
@@ -744,7 +744,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder addItemParamList(emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam value) {
         if (itemParamListBuilder_ == null) {
@@ -760,7 +760,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder addItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam value) {
@@ -777,7 +777,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder addItemParamList(
           emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder builderForValue) {
@@ -791,7 +791,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder addItemParamList(
           int index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder builderForValue) {
@@ -805,7 +805,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder addAllItemParamList(
           java.lang.Iterable<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam> values) {
@@ -820,7 +820,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder clearItemParamList() {
         if (itemParamListBuilder_ == null) {
@@ -833,7 +833,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public Builder removeItemParamList(int index) {
         if (itemParamListBuilder_ == null) {
@@ -846,14 +846,14 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder getItemParamListBuilder(
           int index) {
         return getItemParamListFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder getItemParamListOrBuilder(
           int index) {
@@ -863,7 +863,7 @@ public final class WeaponUpgradeReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public java.util.List<? extends emu.grasscutter.net.proto.ItemParamOuterClass.ItemParamOrBuilder> 
            getItemParamListOrBuilderList() {
@@ -874,14 +874,14 @@ public final class WeaponUpgradeReqOuterClass {
         }
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder addItemParamListBuilder() {
         return getItemParamListFieldBuilder().addBuilder(
             emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.getDefaultInstance());
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder addItemParamListBuilder(
           int index) {
@@ -889,7 +889,7 @@ public final class WeaponUpgradeReqOuterClass {
             index, emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.getDefaultInstance());
       }
       /**
-       * <code>repeated .ItemParam item_param_list = 10;</code>
+       * <code>repeated .ItemParam item_param_list = 8;</code>
        */
       public java.util.List<emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam.Builder> 
            getItemParamListBuilderList() {
@@ -918,7 +918,7 @@ public final class WeaponUpgradeReqOuterClass {
          }
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @return A list containing the foodWeaponGuidList.
        */
       public java.util.List<java.lang.Long>
@@ -927,14 +927,14 @@ public final class WeaponUpgradeReqOuterClass {
                  java.util.Collections.unmodifiableList(foodWeaponGuidList_) : foodWeaponGuidList_;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @return The count of foodWeaponGuidList.
        */
       public int getFoodWeaponGuidListCount() {
         return foodWeaponGuidList_.size();
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @param index The index of the element to return.
        * @return The foodWeaponGuidList at the given index.
        */
@@ -942,7 +942,7 @@ public final class WeaponUpgradeReqOuterClass {
         return foodWeaponGuidList_.getLong(index);
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @param index The index to set the value at.
        * @param value The foodWeaponGuidList to set.
        * @return This builder for chaining.
@@ -955,7 +955,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @param value The foodWeaponGuidList to add.
        * @return This builder for chaining.
        */
@@ -966,7 +966,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @param values The foodWeaponGuidList to add.
        * @return This builder for chaining.
        */
@@ -979,7 +979,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>repeated uint64 food_weapon_guid_list = 1;</code>
+       * <code>repeated uint64 food_weapon_guid_list = 15;</code>
        * @return This builder for chaining.
        */
       public Builder clearFoodWeaponGuidList() {
@@ -991,7 +991,7 @@ public final class WeaponUpgradeReqOuterClass {
 
       private long targetWeaponGuid_ ;
       /**
-       * <code>uint64 target_weapon_guid = 4;</code>
+       * <code>uint64 target_weapon_guid = 14;</code>
        * @return The targetWeaponGuid.
        */
       @java.lang.Override
@@ -999,7 +999,7 @@ public final class WeaponUpgradeReqOuterClass {
         return targetWeaponGuid_;
       }
       /**
-       * <code>uint64 target_weapon_guid = 4;</code>
+       * <code>uint64 target_weapon_guid = 14;</code>
        * @param value The targetWeaponGuid to set.
        * @return This builder for chaining.
        */
@@ -1010,7 +1010,7 @@ public final class WeaponUpgradeReqOuterClass {
         return this;
       }
       /**
-       * <code>uint64 target_weapon_guid = 4;</code>
+       * <code>uint64 target_weapon_guid = 14;</code>
        * @return This builder for chaining.
        */
       public Builder clearTargetWeaponGuid() {
@@ -1088,8 +1088,8 @@ public final class WeaponUpgradeReqOuterClass {
     java.lang.String[] descriptorData = {
       "\n\026WeaponUpgradeReq.proto\032\017ItemParam.prot" +
       "o\"r\n\020WeaponUpgradeReq\022#\n\017item_param_list" +
-      "\030\n \003(\0132\n.ItemParam\022\035\n\025food_weapon_guid_l" +
-      "ist\030\001 \003(\004\022\032\n\022target_weapon_guid\030\004 \001(\004B\033\n" +
+      "\030\010 \003(\0132\n.ItemParam\022\035\n\025food_weapon_guid_l" +
+      "ist\030\017 \003(\004\022\032\n\022target_weapon_guid\030\016 \001(\004B\033\n" +
       "\031emu.grasscutter.net.protob\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor

--- a/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
+++ b/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
@@ -162,7 +162,7 @@ public final class PacketOpcodes {
     public static final int GetAllUnlockNameCardReq = 5009;
     public static final int GetAllUnlockNameCardRsp = 2632;
     public static final int SetPlayerBirthdayReq = 26726;
-    public static final int SetPlayerBirthdayRsp = 9150; 
+    public static final int SetPlayerBirthdayRsp = 9150;
     public static final int GalleryWillStartCountdownNotify = 2443;
     public static final int GetWidgetSlotRsp = 5441;
     public static final int AvatarExpeditionDataNotify = 22907;
@@ -423,9 +423,9 @@ public final class PacketOpcodes {
     public static final int WeaponAwakenRsp = 24076;
     public static final int WeaponPromoteReq = 3230;
     public static final int WeaponPromoteRsp = 25392;
-    public static final int WeaponUpgradeReq = 7713;
+    public static final int WeaponUpgradeReq = 20908;
     public static final int WeaponUpgradeRsp = 22661;
-    public static final int CalcWeaponUpgradeReturnItemsReq = 20908;
+    public static final int CalcWeaponUpgradeReturnItemsReq = 7713;
     public static final int CalcWeaponUpgradeReturnItemsRsp = 6706;
     public static final int SetEquipLockStateReq = 5750;
     public static final int SetEquipLockStateRsp = 26633;


### PR DESCRIPTION
…return items packets were swapped around causing upgrading to be done when selecting xp materials instead of when clicking on the button